### PR TITLE
Updated the ATAT External API per feedback from CCPO:

### DIFF
--- a/provisioning/atat_provisioning.yaml
+++ b/provisioning/atat_provisioning.yaml
@@ -80,7 +80,7 @@ paths:
       tags:
         - cost
       summary: Queries CSP for actual or forecasted cost data by Portfolio
-      operationId: getCosts
+      operationId: getCostsByPortfolio
       parameters:
         - name: portfolioId
           in: path
@@ -111,6 +111,96 @@ paths:
           description: Invalid ID supplied
         '404':
           description: Portfolio not found
+  '/portfolios/{portfolioId}/applications/{applicationId}/cost':
+    post:
+      tags:
+        - cost
+      summary: Queries CSP for actual or forecasted cost data by Application
+      operationId: getCostsByApplication
+      parameters:
+        - name: portfolioId
+          in: path
+          description: ID of the portfolio
+          required: true
+          schema:
+            type: string
+        - name: applicationId
+          in: path
+          description: ID of the Application
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CostRequest'
+            examples:
+              CostRequestActual:
+                $ref: '#/components/examples/CostRequestActual'
+      responses:
+        '200':
+          description: Cost operation successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CostResponse'
+              examples:
+                CostResponseActual:
+                  $ref: '#/components/examples/CostResponseActual'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Portfolio or Application not found
+  '/portfolios/{portfolioId}/applications/{applicationId}/environments/{environmentId}/cost':
+    post:
+      tags:
+        - cost
+      summary: Queries CSP for actual or forecasted cost data by Environment
+      operationId: getCostsByEnvironment
+      parameters:
+        - name: portfolioId
+          in: path
+          description: ID of the portfolio
+          required: true
+          schema:
+            type: string
+        - name: applicationId
+          in: path
+          description: ID of the Application
+          required: true
+          schema:
+            type: string
+        - name: environmentId
+          in: path
+          description: ID of the Environment
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CostRequest'
+            examples:
+              CostRequestActual:
+                $ref: '#/components/examples/CostRequestActual'
+      responses:
+        '200':
+          description: Cost operation successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CostResponse'
+              examples:
+                CostResponseActual:
+                  $ref: '#/components/examples/CostResponseActual'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Portfolio, Application or Environment not found
   '/portfolios/{portfolioId}/applications/{applicationId}/environments/{environmentId}/operator-roles':
     post:
       tags:

--- a/provisioning/atat_provisioning.yaml
+++ b/provisioning/atat_provisioning.yaml
@@ -8,29 +8,20 @@ info:
   contact:
     email: atat-dev+provisioning_api@ccpo.mil
 tags:
-  - name: portfolio
+  - name: provisioning
     description: >-
       Portfolios represent a collection of related Applications under the purview of a
       Mission Owner.
-  - name: funding_source
+  - name: cost
     description: >-
-      Operations to add, update and remove Funding Sources from a given Portfolio
+      Operations to query for actual and forecasted costs by Portfolio
 paths:
   '/portfolios':
     post:
       tags:
-        - portfolio
+        - provisioning
       summary: Adds a new Portfolio
       operationId: addPortfolio
-      responses:
-        '200':
-          description: Successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PortfolioResponse'
-        '405':
-          description: Invalid input
       requestBody:
         description: A new Portfolio
         required: true
@@ -38,10 +29,31 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Portfolio'
+      responses:
+        '200':
+          description: Portfolio fully provisioned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PortfolioResponse'
+        '202':
+          description: Portfolio provisioning request has been accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProvisioningStatus'
+          headers:
+            Location:
+              description: Endpoint which ATAT should poll to receive status updates for this provisioning job
+              schema:
+                type: string
+                example: https://csp.com/jwcc/provisioning/123456789/status
+        '405':
+          description: Invalid input
   '/portfolios/{portfolioId}':
     get:
       tags:
-        - portfolio
+        - provisioning
       summary: Gets an existing Portfolio
       description: Returns a single Portfolio
       operationId: getPortfolioById
@@ -63,12 +75,12 @@ paths:
           description: Invalid ID supplied
         '404':
           description: Portfolio not found
-  '/portfolios/{portfolioId}/funding-sources':
+  '/portfolios/{portfolioId}/cost':
     post:
       tags:
-        - funding_source
-      summary: Adds a new FundingSource to the given Portfolio
-      operationId: addFundingSource
+        - cost
+      summary: Queries CSP for actual or forecasted cost data by Portfolio
+      operationId: getCosts
       parameters:
         - name: portfolioId
           in: path
@@ -76,72 +88,33 @@ paths:
           required: true
           schema:
             type: string
-      responses:
-        '405':
-          description: Invalid input
       requestBody:
-        description: A new FundingSource
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/FundingSource'
-  '/portfolios/{portfolioId}/funding-sources/{fundingSourceId}':
-    put:
-      tags:
-        - funding_source
-      summary: Updates a FundingSource in a given Portfolio
-      operationId: updateFundingSource
-      parameters:
-        - name: portfolioId
-          in: path
-          description: ID of the portfolio
-          required: true
-          schema:
-            type: string
-        - name: fundingSourceId
-          in: path
-          description: ID of the FundingSource
-          required: true
-          schema:
-            type: string
-      responses:
-        '405':
-          description: Invalid input
-      requestBody:
-        description: A FundingSource
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/FundingSource'
-    delete:
-      tags:
-        - funding_source
-      summary: Deletes a FundingSource from a Portfolio
-      operationId: deleteFundingSource
-      parameters:
-        - name: portfolioId
-          in: path
-          description: ID of the portfolio
-          required: true
-          schema:
-            type: string
-        - name: fundingSourceId
-          in: path
-          description: ID of the FundingSource
-          required: true
-          schema:
-            type: string
+              $ref: '#/components/schemas/CostRequest'
+            examples:
+              CostRequestActual:
+                $ref: '#/components/examples/CostRequestActual'
       responses:
         '200':
-          description: Funding Source Deleted
+          description: Cost operation successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CostResponse'
+              examples:
+                CostResponseActual:
+                  $ref: '#/components/examples/CostResponseActual'
+        '400':
+          description: Invalid ID supplied
         '404':
-          description: Invalid Portfolio ID
+          description: Portfolio not found
   '/portfolios/{portfolioId}/applications/{applicationId}/environments/{environmentId}/operator-roles':
     post:
       tags:
-        - portfolio
+        - provisioning
       summary: Assigns an Operator to a specific level of access in an Environment
       description: Assigns an Operator to a specific level of access in an Environment
       operationId: addOperatorRole
@@ -182,6 +155,22 @@ paths:
               $ref: '#/components/schemas/OperatorRole'
 components:
   schemas:
+    ProvisioningStatus:
+      type: object
+      description: >-
+        Represents the status of a provisioning job submitted via POST /portfolios
+      properties:
+        id:
+          type: string
+          description: The ID of the Provisioning job; used for retrieving status to inform end user
+          example: 123456789
+        status:
+          type: string
+          enum:
+            - "NOT_STARTED"
+            - "IN_PROGRESS"
+            - "COMPLETE"
+            - "FAILED"
     Portfolio:
       type: object
       description: >-
@@ -278,6 +267,11 @@ components:
         name:
           type: string
           example: "Production"
+        operator_roles:
+          type: array
+          items:
+            allOf:
+              - $ref: '#/components/schemas/OperatorRole'
     EnvironmentResponse:
       allOf:
         - $ref: '#/components/schemas/Environment'
@@ -301,3 +295,65 @@ components:
           enum:
             - administrator
             - read_only
+    TimePeriod:
+      type: object
+      properties:
+        start_date:
+          type: string
+          format: date
+          example: "2021-10-01"
+        end_date:
+          type: string
+          format: date
+          example: "2021-12-01"
+    CostRequest:
+      type: object
+      properties:
+        period:
+          $ref: '#/components/schemas/TimePeriod'
+        granularity:
+          type: string
+          enum:
+            - "MONTHLY"
+            - "DAILY"
+        type:
+          type: string
+          enum:
+            - "ACTUAL"
+            - "FORECAST"
+    CostResponse:
+      type: object
+      properties:
+        total:
+          type: string
+          description: Total cost (ACTUAL or FORECAST) for entire time period in USD
+          example: "12345.6789"
+        results:
+          type: array
+          items:
+            properties:
+              period:
+                $ref: '#/components/schemas/TimePeriod'
+              value:
+                type: string
+                description: Cost (ACTUAL or FORECAST) for the given time period in USD
+  examples:
+    CostRequestActual:
+      value:
+        period:
+          start_date: "2021-10-01"
+          end_date: "2021-12-01"
+        granularity: "MONTHLY"
+        type: "ACTUAL"
+    CostResponseActual:
+      value:
+        total: "50.00"
+        results:
+          - period:
+              start_date: "2021-10-01"
+              end_date: "2021-11-01"
+            value: "20.00"
+          - period:
+              start_date: "2021-11-01"
+              end_date: "2021-12-01"
+            value: "30.00"


### PR DESCRIPTION
1. Include Operator -> Environment access assignments in initial provisioning package (POST /portfolios)
2. Add Location HTTP Header to POST /portfolios response so that ATAT Orchestrator can track progress (need to create a basic job status schema as well)
3. Remove Funding Sources - ATAT should not need to send this data to the CSPs since they will already have it from the system of record
4. Add operations for obtaining actual spend (up to the most recent billed month) and projected spend for the current billing period

Ticket: AT-6534