### PR TITLE
AT-6696: Small but important tweak

### DIFF
--- a/provisioning/atat_provisioning.yaml
+++ b/provisioning/atat_provisioning.yaml
@@ -354,6 +354,11 @@ components:
           items:
             allOf:
               - $ref: '#/components/schemas/Application'
+        operator_roles:
+          type: array
+          items:
+            allOf:
+              - $ref: '#/components/schemas/PortfolioOperatorRole'
     PortfolioResponse:
       allOf:
         - $ref: '#/components/schemas/Portfolio'
@@ -404,6 +409,11 @@ components:
           items:
             allOf:
               - $ref: '#/components/schemas/Environment'
+        operator_roles:
+          type: array
+          items:
+            allOf:
+              - $ref: '#/components/schemas/ApplicationOperatorRole'
     ApplicationResponse:
       allOf:
         - type: object


### PR DESCRIPTION
Updated the ATAT External API to include `operator_roles` arrays at the Portfolio and Application level in the `POST /portfolios` route

Ticket: AT-6696