### PR TITLE
Add optional X-Atat-Api-Version header

### DIFF
--- a/provisioning/atat_provisioning.yaml
+++ b/provisioning/atat_provisioning.yaml
@@ -61,6 +61,15 @@ paths:
           schema:
             type: string
             format: date-time
+        - name: X-Atat-Api-Version
+          description: >-
+            This header may be provided by an ATAT client implementation to provide context for the ATAT API specification
+            that it expects to be compatible with. Implementations may choose to adapt their response to conform to the
+            expected API version. If not provided by the client, the server should assume the client supports the latest
+            version of this specification.
+          in: header
+          schema:
+            type: string
       requestBody:
         description: A new Portfolio
         required: true
@@ -113,6 +122,15 @@ paths:
           in: header
           schema:
             $ref: '#/components/schemas/ImpactLevel'
+        - name: X-Atat-Api-Version
+          description: >-
+            This header may be provided by an ATAT client implementation to provide context for the ATAT API specification
+            that it expects to be compatible with. Implementations may choose to adapt their response to conform to the
+            expected API version. If not provided by the client, the server should assume the client supports the latest
+            version of this specification.
+          in: header
+          schema:
+            type: string
       responses:
         '200':
           description: Portfolio successfully retrieved
@@ -160,6 +178,15 @@ paths:
           in: header
           schema:
             $ref: '#/components/schemas/ImpactLevel'
+        - name: X-Atat-Api-Version
+          description: >-
+            This header may be provided by an ATAT client implementation to provide context for the ATAT API specification
+            that it expects to be compatible with. Implementations may choose to adapt their response to conform to the
+            expected API version. If not provided by the client, the server should assume the client supports the latest
+            version of this specification.
+          in: header
+          schema:
+            type: string
       requestBody:
         description: A PortfolioPatch object
         required: true
@@ -217,6 +244,15 @@ paths:
           in: header
           schema:
             $ref: '#/components/schemas/ImpactLevel'
+        - name: X-Atat-Api-Version
+          description: >-
+            This header may be provided by an ATAT client implementation to provide context for the ATAT API specification
+            that it expects to be compatible with. Implementations may choose to adapt their response to conform to the
+            expected API version. If not provided by the client, the server should assume the client supports the latest
+            version of this specification.
+          in: header
+          schema:
+            type: string
       responses:
         '200':
           description: Cost operation successful
@@ -254,6 +290,15 @@ paths:
           in: header
           schema:
             $ref: '#/components/schemas/ImpactLevel'
+        - name: X-Atat-Api-Version
+          description: >-
+            This header may be provided by an ATAT client implementation to provide context for the ATAT API specification
+            that it expects to be compatible with. Implementations may choose to adapt their response to conform to the
+            expected API version. If not provided by the client, the server should assume the client supports the latest
+            version of this specification.
+          in: header
+          schema:
+            type: string
       responses:
         '200':
           description: Successful operation
@@ -300,6 +345,15 @@ paths:
           in: header
           schema:
             $ref: '#/components/schemas/ImpactLevel'
+        - name: X-Atat-Api-Version
+          description: >-
+            This header may be provided by an ATAT client implementation to provide context for the ATAT API specification
+            that it expects to be compatible with. Implementations may choose to adapt their response to conform to the
+            expected API version. If not provided by the client, the server should assume the client supports the latest
+            version of this specification.
+          in: header
+          schema:
+            type: string
       responses:
         '200':
           description: Successful operation
@@ -368,6 +422,15 @@ paths:
           in: header
           schema:
             $ref: '#/components/schemas/ImpactLevel'
+        - name: X-Atat-Api-Version
+          description: >-
+            This header may be provided by an ATAT client implementation to provide context for the ATAT API specification
+            that it expects to be compatible with. Implementations may choose to adapt their response to conform to the
+            expected API version. If not provided by the client, the server should assume the client supports the latest
+            version of this specification.
+          in: header
+          schema:
+            type: string
       responses:
         '200':
           description: Cost operation successful


### PR DESCRIPTION
As the ATAT API specification is modified ahead of a v1.0.0, it may be
helpful for client implementations to indicate the specific version that
they support and are expecting for the response. This new header is
entirely optional and purely informative.

Alternative solution here may have included:

* Leveraging the `Accept` headers -- this was not done because it would
  be a bit awkward to properly represent in the OpenAPI specification as
  we'd want to define the specific models that we expect in the
  response for the different headers. It would also suggest that we'd
  want a 406 Not Acceptable response if the server didn't support the
  given version; at this stage, we likely want to have everyone do their
  best to use and pass data around. Perhaps at/after stabilization the
  goals might be different.
* Expecting implementations to use path-based versioning -- this works
  for discrete versioning like /api/v1 or /api/v2, but gets awkward for
  pre-v1. Additionally, it implies too much burden to manually
  understand what each implementor supports.
* Expecting that everyone supports the latest version -- this basically
  what we were doing before. There was uncertainty about when a
  particular version was expected; at least with this there is a
  concrete way for partners to monitor what version of the API a client
  is expecting; some implementations may choose to support multiple
  versions and return a response compatible with an older version.

The downsides primarily are that this adds an additional header and that
it doesn't provide any help if a server implementation does not yet
support a new path; however, at least the client would potentially
include this header.

Clients really should include this header but it entirely optional and
not marked as being a "should do" to avoid anyone relying on this header
or assigning too much meaning to it.

In review, please ensure that the wording of the description meets the
intent and that there aren't typos or other mistakes.
