### PR TITLE
Use a single object for CostData-type responses

### DIFF
--- a/provisioning/atat_provisioning.yaml
+++ b/provisioning/atat_provisioning.yaml
@@ -540,13 +540,9 @@ components:
         - forecast
       properties:
         actual:
-          type: array
-          items:
-            $ref: '#/components/schemas/CostData'
+          $ref: '#/components/schemas/CostData'
         forecast:
-          type: array
-          items:
-            $ref: '#/components/schemas/CostData'
+          $ref: '#/components/schemas/CostData'
     CostResponseByPortfolio:
       description: >-
         Provides cost data in a format in accordance with the provided CostRequest. For any time periods for which
@@ -568,13 +564,9 @@ components:
                     clin_number:
                       type: string
                     actual:
-                      type: array
-                      items:
-                        $ref: '#/components/schemas/CostData'
+                      $ref: '#/components/schemas/CostData'
                     forecast:
-                      type: array
-                      items:
-                        $ref: '#/components/schemas/CostData'
+                      $ref: '#/components/schemas/CostData'
     CostData:
       required:
         - total
@@ -611,32 +603,32 @@ components:
             clins:
               - clin_number: "0001"
                 actual:
-                  - total: "50.00"
-                    results:
-                      - month: "2021-12"
-                        value: "20.00"
-                      - month: "2022-01"
-                        value: "30.00"
+                  total: "50.00"
+                  results:
+                    - month: "2021-12"
+                      value: "20.00"
+                    - month: "2022-01"
+                      value: "30.00"
                 forecast:
-                  - total: "100.00"
-                    results:
-                      - month: "2022-02"
-                        value: "100.00"
+                  total: "100.00"
+                  results:
+                    - month: "2022-02"
+                      value: "100.00"
               - clin_number: "0002"
                 actual:
-                  - total: "750.00"
-                    results:
-                      - month: "2021-12"
-                        value: "50.00"
-                      - month: "2022-01"
-                        value: "700.00"
+                  total: "750.00"
+                  results:
+                    - month: "2021-12"
+                      value: "50.00"
+                    - month: "2022-01"
+                      value: "700.00"
                 forecast:
-                  - total: "1000.00"
-                    results:
-                      - month: "2022-02"
-                        value: "100.00"
-                      - month: "2022-03"
-                        value: "900.00"
+                  total: "1000.00"
+                  results:
+                    - month: "2022-02"
+                      value: "100.00"
+                    - month: "2022-03"
+                      value: "900.00"
   securitySchemes:
     oidc:
       description: >-


### PR DESCRIPTION
The previous model allowed for an array of `CostData` objects in most
situations. This resulted in a structure where it's unclear why there
would be separation into multiple arrays and when/how to do so. Instead,
for the given date range, all results should be included in a single
`CostData` object and the months should be within the `results` array
inside the `CostData` object.

The `CostResponsebyClin` example already was using this single-item
format in its example; the `CostResponseByPortfolio` examples have been
updated to match the new specification.
