### PR TITLE
Release 1.0.2

### DIFF
--- a/provisioning/atat_provisioning.yaml
+++ b/provisioning/atat_provisioning.yaml
@@ -560,8 +560,11 @@ components:
           example: "csp-portfolio-id-123"
         dashboard_link:
           description: >-
-            Represents a deep link to the Portfolio as represented in the vendor's dashboard. Allows ATAT to provide direct links to a Mission Owner's Portfolio within the vendor's environment.
+            Represents a deep link to the Portfolio as represented in the vendor's dashboard. Allows ATAT to provide
+            direct links to a Mission Owner's Portfolio within the vendor's environment. Will NOT be supplied by the
+            ATAT Client on initial POST /portfolios, but is expected to be provided upon successful Portfolio creation.
           type: string
+          readOnly: true
           format: uri
           example: "https://vendor.com/account/csp-portfolio-id-123"
     TaskOrder:
@@ -581,6 +584,9 @@ components:
           readOnly: true
           example: "csp-portfolio-id-123"
         task_order_number:
+          description: >-
+            Represents the current Task Order Number. Subject to change over the lifetime of a Task Order. Should be
+            considered metadata rather than a primary key (use the `id` instead).
           type: string
           example: "1234567891234"
         clins:
@@ -674,6 +680,8 @@ components:
           type: array
           items:
             properties:
+              task_order_id:
+                type: string
               task_order_number:
                 type: string
               clins:

--- a/provisioning/atat_provisioning.yaml
+++ b/provisioning/atat_provisioning.yaml
@@ -21,7 +21,7 @@ info:
 
     Provisioned resources incur costs with participating CSPs. Costs related to provisioned resources can
     be attributed to specific CLINs. Actual and forecasted CSP costs can be reported by CLIN.
-  version: 1.0.1
+  version: 1.0.2
   title: ATAT CSP API
   contact:
     email: atat-dev+provisioning_api@ccpo.mil


### PR DESCRIPTION
- Setting dashboard_link as readOnly
- Clarifying distinction between the `id` and `task_order_number` fields in TaskOrder
- Adding `task_order_id` to CostResponseByPortfolio