### PR TITLE
AT-9754 - Update ATAT specification to support migrations

### DIFF
--- a/provisioning/atat_provisioning.yaml
+++ b/provisioning/atat_provisioning.yaml
@@ -481,6 +481,12 @@ components:
           items:
             allOf:
               - $ref: '#/components/schemas/TaskOrder'
+        migrationOfPortfolioRequired:
+          description: >-
+            A boolean value representing whether or not the Portfolio being created by the vendor requires the 
+            migration of existing cloud resources.
+          type: boolean
+          
     Portfolio:
       allOf:
         - $ref: '#/components/schemas/PortfolioCreate'


### PR DESCRIPTION
Added optional property on PortfolioCreate object to represent `migrationOfPortfolioRequired`.