### PR TITLE
ATAT Spec v1.3.0 Draft

### DIFF
--- a/provisioning/atat_provisioning.yaml
+++ b/provisioning/atat_provisioning.yaml
@@ -26,7 +26,7 @@ info:
 
     Provisioned resources incur costs with participating CSPs. Costs related to provisioned resources can
     be attributed to specific CLINs. Actual and forecasted CSP costs can be reported by CLIN.
-  version: 1.2.0
+  version: 1.3.0
   title: ATAT CSP API
   contact:
     email: disa.meade.hacc.list.hc2-atat-dev-provisioning-api@mail.mil
@@ -416,6 +416,52 @@ paths:
                 $ref: '#/components/schemas/ProvisioningStatus'
         '404':
           description: Provisioning Job ID not found
+  '/far51':
+    parameters:
+      - $ref: '#/components/parameters/ApiVersion'
+    get:
+      tags:
+        - cost
+      summary: Gets all FAR Part 51 Authorizations
+      security:
+        - oidc: [atat/read-portfolio]
+      description: >-
+        Returns an array of FAR Part 51 Authorizations known to the vendor, so that the ATAT client can track them. This
+        must be fulfilled in this way because FAR Part 51 Authorizations are not processed through the ATAT UI in the
+        same fashion as Portfolios, Task Orders and Environments. Must return up to 100 FAR Part 51 Authorizations which
+        were created after the provided `start_date` and before the provided `end_date` query parameters, sorted by
+        `created_at`.
+      operationId: getFarPart51Authorizations
+      parameters:
+        - name: start_date
+          in: query
+          description: >-
+            Start date of the request in YYYY-MM format.
+          required: true
+          schema:
+            type: string
+            format: date
+            example: "2021-12"
+        - name: end_date
+          in: query
+          description: >-
+            End date of the request in YYYY-MM format.
+          required: true
+          schema:
+            type: string
+            format: date
+            example: "2026-12"
+      responses:
+        '200':
+          description: FAR Part 51 Authorizations successfully retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Far51Authorization'
+        '400':
+          description: Missing required parameter
 components:
   parameters:
     ApiVersion:
@@ -515,8 +561,7 @@ components:
         environments:
           type: array
           items:
-            allOf:
-              - $ref: '#/components/schemas/Environment'
+            $ref: '#/components/schemas/EnvironmentResponse'
     EnvironmentPatch:
       properties:
         administrators:
@@ -547,7 +592,7 @@ components:
           example: "Sample Environment name"
         account_name:
           description: >-
-            Text which is meant to represent a name that uniquely identifies this Environment in the vendor cloud 
+            Text which is meant to represent a name that uniquely identifies this Environment in the vendor cloud
             which can be used in part of a host name or URL.
           type: string
           example: "sampleenvironment-a_1"
@@ -575,7 +620,7 @@ components:
           $ref: '#/components/schemas/CloudDistinguisher'
         is_migration:
           description: >-
-            A boolean value representing whether or not the Environment being created requires the migration of 
+            A boolean value representing whether or not the Environment being created requires the migration of
             existing cloud resources.
           type: boolean
           default: false
@@ -691,18 +736,69 @@ components:
         - UNCLASSIFIED
         - SECRET
         - TOP_SECRET
+    Far51Authorization:
+      description: >-
+        An authorization to spend contract funds under FAR Part 51 (see https://www.acquisition.gov/far/part-51).
+      properties:
+        id:
+          type: string
+          description: Unique identifier for this FAR Part 51 Authorization. Used for retrieval of cost data.
+          example: "csp-far-51-id-123"
+        created_at:
+          description: >-
+            Date this FAR Part 51 Authorization was created by the vendor's ATAT implementation in YYYY-MM-DD format.
+          type: string
+          format: date
+          example: "2021-03-28"
+        contract_number:
+          description: Contract Number under which this FAR Part 51 Authorization was granted
+          type: string
+          example: "N0006217D0001"
+        delivery_order_number:
+          description: Delivery Order Number under which this FAR Part 51 Authorization was granted
+          type: string
+          example: "N0006217F0001"
+        pop_start_date:
+          description: Start of period of performance for this FAR Part 51 Authorization in YYYY-MM-DD format.
+          type: string
+          format: date
+          example: "2021-07-15"
+        pop_end_date:
+          description: End of period of performance for this FAR Part 51 Authorization in YYYY-MM-DD format.
+          type: string
+          format: date
+          example: "2026-07-14"
+        customer_department:
+          description: >-
+            Abbreviation for Agency or Department associated with this FAR Part 51 Authorization, e.g. AF, Army, DLA, DOJ
+          type: string
+          example: "DOJ"
+        authorizing_contract_officer:
+          description: Contact information for authorizing Contract Officer
+          type: object
+          properties:
+            name:
+              type: string
+              example: "Jane Contractor"
+            telephone:
+              type: string
+              example: "555-123-4567"
+            email:
+              type: string
+              format: email
+              example: "jane@agency.gov"
     CostResponseByClin:
       description: >-
         Provides cost data in a format in accordance with the provided CostRequest. Implementors must provide actual
         data for any month in which real costs has been incurred, whether or not they have been invoiced. Forecast data
-        should be supplied for any month which has not been invoiced. Specifically, this implies the following 
+        should be supplied for any month which has not been invoiced. Specifically, this implies the following
         expectations:
-        
-          * Invoiced Past Months - actuals only 
+
+          * Invoiced Past Months - actuals only
           * Un-invoiced Past Months - actuals and forecasts
           * Current Month - actuals and forecasts
           * Future Months - forecasts only
-        
+
         **Note**: Forecast data is only required for Clin's whose `type` is "CLOUD". For instance, vendors are not
         expected to provide forecast data for expenses such as travel or training.
       required:
@@ -739,10 +835,10 @@ components:
       description: >-
         Provides cost data in a format in accordance with the provided CostRequest. Implementors must provide actual
         data for any month in which real costs has been incurred, whether or not they have been invoiced. Forecast data
-        should be supplied for any month which has not been invoiced. Specifically, this implies the following 
+        should be supplied for any month which has not been invoiced. Specifically, this implies the following
         expectations:
-        
-          * Invoiced Past Months - actuals only 
+
+          * Invoiced Past Months - actuals only
           * Un-invoiced Past Months - actuals and forecasts
           * Current Month - actuals and forecasts
           * Future Months - forecasts only

--- a/provisioning/atat_provisioning.yaml
+++ b/provisioning/atat_provisioning.yaml
@@ -18,7 +18,7 @@ info:
 
     ## Task Orders
 
-    Portfolios contain one or more *Task Orders* (TO), which in turn contain or more or *Contract Line Item Number*
+    Portfolios contain one or more *Task Orders* (TO), which in turn contain or more or *Contract Line Item Numbers*
     (CLINs). Each have separate Periods of Performance (PoP) dates; CLIN PoP dates will be within the time frames of
     the Task Order in which they belong.
 
@@ -126,7 +126,7 @@ paths:
         - name: end_date
           in: query
           description: >-
-            End date of the cost data request in YYYY-MM format. Must not succeed the latest pop_end_date of the given
+            End date of the cost data request in YYYY-MM format. Must not exceed the latest pop_end_date of the given
             Portfolio's Task Orders.
           required: true
           schema:
@@ -239,7 +239,7 @@ paths:
         - name: end_date
           in: query
           description: >-
-            End date of the cost data request in YYYY-MM format. Must not succeed the earliest pop_start_date of the
+            End date of the cost data request in YYYY-MM format. Must not exceed the latest pop_end_date of the
             given CLIN.
           required: true
           schema:
@@ -372,7 +372,7 @@ paths:
               $ref: '#/components/schemas/EnvironmentPatch'
       responses:
         '200':
-          description: Portfolio successfully updated
+          description: Environment successfully updated
           content:
             application/json:
               schema:
@@ -453,10 +453,10 @@ paths:
         - oidc: [atat/read-portfolio]
       description: >-
         Returns an array of FAR Part 51 Authorizations known to the vendor, so that the ATAT client can track them. This
-        must be fulfilled in this way because FAR Part 51 Authorizations are not processed through the ATAT UI in the
-        same fashion as Portfolios, Task Orders and Environments. Must return up to 100 FAR Part 51 Authorizations which
-        were created after the provided `start_date` and before the provided `end_date` query parameters, sorted by
-        `created_at`.
+        information must be provided in this way (sourced by the vendor rather than the ATAT client) because FAR Part 51
+        Authorizations are not processed through the ATAT UI in the same fashion as Portfolios, Task Orders and 
+        Environments. Must return up to 100 FAR Part 51 Authorizations which were created after the provided 
+        `start_date` and before the provided `end_date` query parameters (inclusive), sorted by `created_at`.
       operationId: getFarPart51Authorizations
       parameters:
         - name: start_date

--- a/provisioning/atat_provisioning.yaml
+++ b/provisioning/atat_provisioning.yaml
@@ -26,7 +26,7 @@ info:
 
     Provisioned resources incur costs with participating CSPs. Costs related to provisioned resources can
     be attributed to specific CLINs. Actual and forecasted CSP costs can be reported by CLIN.
-  version: 1.3.0
+  version: 1.2.0
   title: ATAT CSP API
   contact:
     email: disa.meade.hacc.list.hc2-atat-dev-provisioning-api@mail.mil
@@ -416,6 +416,32 @@ paths:
                 $ref: '#/components/schemas/ProvisioningStatus'
         '404':
           description: Provisioning Job ID not found
+  '/task-orders/{taskOrderNumber}':
+    parameters:
+      - $ref: '#/components/parameters/ApiVersion'
+    head:
+      tags:
+        - provisioning
+      summary: Determines if a given Task Order is ready to be used for provisioning
+      security:
+        - oidc: [atat/read-portfolio]
+      description: >-
+        Vendors should return a 200 if the provided Task Order Number is ready to be used for provisioning and 400
+        otherwise.
+      operationId: checkTaskOrder
+      parameters:
+        - name: taskOrderNumber
+          description: Task Order Number
+          example: "N0006217F0001"
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The given Task Order is ready to be used for Portfolio provisioning
+        '400':
+          description: The given Task Order is not ready to be used for Portfolio provisioning
   '/far51':
     parameters:
       - $ref: '#/components/parameters/ApiVersion'
@@ -458,10 +484,64 @@ paths:
             application/json:
               schema:
                 type: array
+                maxItems: 100
+                uniqueItems: true
                 items:
                   $ref: '#/components/schemas/Far51Authorization'
         '400':
           description: Missing required parameter
+  '/far51/{far51AuthorizationId}/costs':
+    parameters:
+      - $ref: '#/components/parameters/ApiVersion'
+    get:
+      tags:
+        - cost
+      summary: Returns cost data for a FAR 51 Authorization
+      security:
+        - oidc: [atat/read-cost]
+      description: >-
+        Queries CSP for actual cost data for a given FAR Part 51 Authorization and time period. Queries should return
+        data for all months included in date ranges. For example, a start_date of "2022-01-25" and end_date of
+        "2022-03-02" should return data for January, February and March.
+      operationId: getCostsByFar51Authorization
+      parameters:
+        - name: start_date
+          in: query
+          description: >-
+            Start date of the cost data request in YYYY-MM format.
+          required: true
+          schema:
+            type: string
+            format: date
+            example: "2021-12"
+        - name: end_date
+          in: query
+          description: >-
+            End date of the cost data request in YYYY-MM format.
+          required: true
+          schema:
+            type: string
+            format: date
+            example: "2026-12"
+        - name: far51AuthorizationId
+          description: ID of the FAR Part 51 Authorization
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Cost operation successful
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CostData'
+        '400':
+          description: Invalid ID or query parameters
+        '404':
+          description: Far Part 51 Authorization not found
 components:
   parameters:
     ApiVersion:

--- a/provisioning/atat_provisioning.yaml
+++ b/provisioning/atat_provisioning.yaml
@@ -73,6 +73,8 @@ paths:
                 $ref: '#/components/schemas/PortfolioCreate'
         '400':
           description: Invalid input
+        '405':
+          description: Not ready to provision
   '/portfolios/{portfolioId}':
     parameters:
       - $ref: '#/components/parameters/ApiVersion'
@@ -325,6 +327,8 @@ paths:
           description: Invalid ID supplied
         '404':
           description: Portfolio not found
+        '405':
+          description: Not ready to provision
       requestBody:
         required: true
         content:
@@ -416,32 +420,6 @@ paths:
                 $ref: '#/components/schemas/ProvisioningStatus'
         '404':
           description: Provisioning Job ID not found
-  '/task-orders/{taskOrderNumber}':
-    parameters:
-      - $ref: '#/components/parameters/ApiVersion'
-    head:
-      tags:
-        - provisioning
-      summary: Determines if a given Task Order is ready to be used for provisioning
-      security:
-        - oidc: [atat/read-portfolio]
-      description: >-
-        Vendors should return a 200 if the provided Task Order Number is ready to be used for provisioning and 400
-        otherwise.
-      operationId: checkTaskOrder
-      parameters:
-        - name: taskOrderNumber
-          description: Task Order Number
-          example: "N0006217F0001"
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: The given Task Order is ready to be used for Portfolio provisioning
-        '400':
-          description: The given Task Order is not ready to be used for Portfolio provisioning
   '/far51':
     parameters:
       - $ref: '#/components/parameters/ApiVersion'
@@ -455,14 +433,14 @@ paths:
         Returns an array of FAR Part 51 Authorizations known to the vendor, so that the ATAT client can track them. This
         information must be provided in this way (sourced by the vendor rather than the ATAT client) because FAR Part 51
         Authorizations are not processed through the ATAT UI in the same fashion as Portfolios, Task Orders and 
-        Environments. Must return up to 100 FAR Part 51 Authorizations which were created after the provided 
-        `start_date` and before the provided `end_date` query parameters (inclusive), sorted by `created_at`.
+        Environments. Must return an array of FAR Part 51 Authorizations, subject to the `limit` and `offset` pagination 
+        parameters as well as the `start_date` and `end_date` query parameters, sorted by `created_at`.
       operationId: getFarPart51Authorizations
       parameters:
         - name: start_date
           in: query
           description: >-
-            Start date of the request in YYYY-MM format.
+            Start date of the request in YYYY-MM format (inclusive). Earliest allowed value is `2023-01`.
           required: true
           schema:
             type: string
@@ -471,12 +449,14 @@ paths:
         - name: end_date
           in: query
           description: >-
-            End date of the request in YYYY-MM format.
+            End date of the request in YYYY-MM format (inclusive).
           required: true
           schema:
             type: string
             format: date
             example: "2026-12"
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
       responses:
         '200':
           description: FAR Part 51 Authorizations successfully retrieved
@@ -489,7 +469,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/Far51Authorization'
         '400':
-          description: Missing required parameter
+          description: Missing required parameter or invalid parameter
   '/far51/{far51AuthorizationId}/costs':
     parameters:
       - $ref: '#/components/parameters/ApiVersion'
@@ -502,13 +482,15 @@ paths:
       description: >-
         Queries CSP for actual cost data for a given FAR Part 51 Authorization and time period. Queries should return
         data for all months included in date ranges. For example, a start_date of "2022-01-25" and end_date of
-        "2022-03-02" should return data for January, February and March.
+        "2022-03-02" should return data for January, February and March. If the date range requested by the client
+        includes periods for which no data exists, the server must return whatever matching cost data does exist rather
+        than respond with an error code.
       operationId: getCostsByFar51Authorization
       parameters:
         - name: start_date
           in: query
           description: >-
-            Start date of the cost data request in YYYY-MM format.
+            Start date of the cost data request in YYYY-MM format (inclusive). Earliest allowed value is `2023-01`.
           required: true
           schema:
             type: string
@@ -517,7 +499,7 @@ paths:
         - name: end_date
           in: query
           description: >-
-            End date of the cost data request in YYYY-MM format.
+            End date of the cost data request in YYYY-MM format (inclusive).
           required: true
           schema:
             type: string
@@ -554,6 +536,23 @@ components:
       in: header
       schema:
         type: string
+    Limit:
+      name: limit
+      description: Maximum number of results to be returned for a given request
+      in: query
+      schema:
+        type: integer
+        default: 10
+        minimum: 1
+        maximum: 100
+    Offset:
+      name: offset
+      description: Offset for use when returning the n-th page of results (0-indexed)
+      in: query
+      schema:
+        type: integer
+        default: 0
+        minimum: 0
     PortfolioId:
       name: portfolioId
       description: ID of the Portfolio

--- a/provisioning/atat_provisioning.yaml
+++ b/provisioning/atat_provisioning.yaml
@@ -26,7 +26,7 @@ info:
 
     Provisioned resources incur costs with participating CSPs. Costs related to provisioned resources can
     be attributed to specific CLINs. Actual and forecasted CSP costs can be reported by CLIN.
-  version: 1.2.0
+  version: 1.3.0
   title: ATAT CSP API
   contact:
     email: disa.meade.hacc.list.hc2-atat-dev-provisioning-api@mail.mil

--- a/provisioning/atat_provisioning.yaml
+++ b/provisioning/atat_provisioning.yaml
@@ -172,6 +172,8 @@ paths:
           description: Invalid ID supplied
         '404':
           description: Portfolio not found
+        '405':
+          description: Not ready to provision
       requestBody:
         required: true
         content:
@@ -202,6 +204,8 @@ paths:
           description: Invalid ID supplied
         '404':
           description: Portfolio or Task Order not found
+        '405':
+          description: Not ready to provision
       requestBody:
         required: true
         content:


### PR DESCRIPTION
This update is largely aimed at adding support for FAR Part 51 Authorizations for JWCC. It also includes a few assorted small fixes as well as a new operation to check the status of an issued Task Order.

### Details:

- Added FAR Part 51 object and accompanying GET operation.
- Updated Portfolio object's environments property to EnvironmentResponse and removed undesirable 'allOf' declaration
- Added getCostsByFar51Authorization operation
- Added maxItems and uniqueItems to `GET /far51` response
- Added `405` response code to `addPortfolio` operation, which indicates that provisioning a Portfolio with the given Task Order is not possible yet 
- Added `405` response code to `addEnvironment` operation, which indicates that provisioning a Environment at the given Classification Level is not possible yet 